### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ MAINTAINER "Joshua C. Randall" <jcrandall@alum.mit.edu>
 # Prerequisites
 RUN \
   apt-get update && \
-  apt-get -y upgrade && \
-  apt-get install -y python python-pip python-dev
-
-
+  apt-get install -y --no-install-recommends \
+  python python-pip python-dev && \
+  rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Hi, this is Mizzlr. I have updated your dockerfile with a few change to reduce the image size. The original image size is about 431 MB while the modified dockerfile builds to an image of size 278 MB. That is about 35% reduction in size. Doing apt-get upgrade in a layer does not help apt-get install within the same layer. So, I just removed it (as it is not used apt-get). Added rm -rf /var/lib/apt/lists/\* to clean-up the package lists. These are good practices with dockerfile. I have built and tested the image from the dockerfile. Please accept my proposal for dockerfile change. Thank you. 👍  :)
